### PR TITLE
feat(plugin): using annotations for mappings

### DIFF
--- a/.changeset/wicked-pants-attend.md
+++ b/.changeset/wicked-pants-attend.md
@@ -1,0 +1,5 @@
+---
+"@eventcatalog/backstage-plugin-eventcatalog": major
+---
+
+feat(plugin): using annotations for mappings

--- a/README.md
+++ b/README.md
@@ -49,39 +49,64 @@ This plugin exposes React components that you can embed on your pages to display
 yarn add @eventcatalog/backstage-plugin-eventcatalog
 ```
 
-### 2. Setting up the app-config.yml
+### 2. Add the EventCatalog URL to the app-config.yaml
+
+The EventCatalog plugin needs to know the URL of your EventCatalog instance. This can be set in the `app-config.yaml` file.
+
+```yaml
+eventcatalog:
+  URL: "https://demo.eventcatalog.dev"
+```
+
+### 3. Mapping Backstage resources to EventCatalog resources with annotations
 
 Backstage and EventCatalog have different ways to create resources. For example backstage supports components, APIS, domains, systems etc, and EventCatalog supports resources (domains, services and messages (queries, commands and events)).
 
 When you configure the plugin you need to map Backstage information to EventCatalog information, so the plugin knows which EventCatalog page to render.
 
-You need to add plugin configuration to your `app-config.yaml` file.
+We do this by adding annotations to the Backstage resources.
+
+<!-- Make table -->
+
+| Annotation | Required | Default | Description |
+|------------|----------|---------|-------------|
+| `eventcatalog.dev/id` | Yes | - | The id of the resource in EventCatalog |
+| `eventcatalog.dev/version` | No | `latest` | The version of the resource in EventCatalog |
+| `eventcatalog.dev/collection` | No | Uses the entity kind | The collection of the resource in EventCatalog. Options include `services`, `domains`, `queries`, `commands`, `events` |
+
+Example of creating a new service in Backstage and mapping it to an EventCatalog resource:
 
 ```yaml
-# eventcatalog namespace
-eventcatalog:
-  # URL of your catalog (has to be public, if private please raise and issue and we can fix his)
-  URL: "https://demo.eventcatalog.dev"
-  # map your services (Components type="Service") to EventCatalog services
-  services:
-    # The name of the service in backstage
-    - backstage-name: "backend-service"
-      # The id of the service in EventCatalog
-      eventcatalog-id: "InventoryService"
-      # (optional) the filter value for your discovery table embed
-      eventcatalog-page-discovery-default-filter: "Inventory Service"
-    - backstage-name: "backend-service2"
-      eventcatalog-id: "Orders"
-      eventcatalog-version: "1.0.0"
-  # map your APIS (kind: API) to EventCatalog
-  apis:
-    - backstage-name: "example-grpc-api"
-      eventcatalog-id: "NotificationService"
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: backend-service
+  description: Backend API service
+  annotations:
+    github.com/project-slug: organization/backend-repo
+    # Here we map the Backstage service to an EventCatalog resource
+    # The id of the resource in EventCatalog
+    eventcatalog.dev/id: InventoryService
+    # The version of the resource in EventCatalog
+    eventcatalog.dev/version: 0.0.2
+    # The collection of the resource in EventCatalog
+    eventcatalog.dev/collection: services
+  tags:
+    - nodejs
+    - express
+    - api
+spec:
+  type: service
+  lifecycle: production
+  owner: team-name
+  system: example-system
+  providesApis:
+    - backend-api
+  dependsOn:
+    - resource:default/database
 ```
 
-The EventCatalog plugin will read these values and map your pages to the correct EventCatalog pages.
-
-### 3. Using the components
+### 4. Using the components
 
 _Assumes a new Backstage installation, install guides my vary_.
 

--- a/src/components/DocumentationEntity/index.tsx
+++ b/src/components/DocumentationEntity/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
+import { useApi, configApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { useEntity } from '@backstage/plugin-catalog-react';
-import { useApi, configApiRef } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
-import {} from '../..';
-import { EventCatalogConfig, getConfig, ResourceMap } from '../../config';
 
 interface Props {
   page: 'docs' | 'visualiser' | 'discover';
@@ -25,104 +23,70 @@ const getEventCatalogCollectionFromEntity = (entity: Entity) => {
     return 'services';
   }
 
-  if(isEntityDomain(entity)) {
+  if (isEntityDomain(entity)) {
     return 'domains';
   }
 
   return null;
 };
 
-const getEventCatalogValuesFromEntity = (entity: Entity, map: ResourceMap[]) => {
+export function getConfig(config: ConfigApi) {
+  const pluginConfig = config.getConfig('eventcatalog');
 
-    const data = map.find(
-        item => item['backstage-name'] === entity.metadata.name,
-    );
-    
-    if (!data) return null;
-
-    let version = data['eventcatalog-version'] || '';
-    version = version === 'latest' ? '' : version;
-    
-    return { id: data['eventcatalog-id'], version, discoverFilter: data['eventcatalog-page-discovery-default-filter'] };
-
+  return {
+    URL: pluginConfig.getString('URL')
+  };
 }
 
-const backstageToCatalogResourceName = (
-  entity: Entity,
-  pluginConfig: EventCatalogConfig,
-): { id: string; version?: string, discoverFilter?: string  } | null => {
-  const { services = [], apis = [] } = pluginConfig;
+export const EventCatalogDocumentationEntityPage = (props: Props) => {
+  const { page = 'docs' } = props;
+  const resource = useEntity();
 
-  if (isEntityService(entity)) {
-    return getEventCatalogValuesFromEntity(entity, [...services, ...apis]);
-  }
-
-  return null;
-};
-
-export const EventCatalogDocumentationEntityPage = ({
-  page = 'docs',
-}: Props) => {
-  const { entity } = useEntity();
   const config = useApi(configApiRef);
   const pluginConfig = getConfig(config);
 
-  const collection = getEventCatalogCollectionFromEntity(entity);
+  const eventCatalogResourceId = resource.entity.metadata.annotations?.['eventcatalog.dev/id'] || null;
+  const eventCatalogResourceVersion = resource.entity.metadata.annotations?.['eventcatalog.dev/version'] || null;
+  const eventCatalogResourceCollection = resource.entity.metadata.annotations?.['eventcatalog.dev/collection'] || null;
 
-  if (!collection) {
+  const collection = eventCatalogResourceCollection || getEventCatalogCollectionFromEntity(resource.entity);
+
+  if (!eventCatalogResourceId) {
     return (
       <div style={{ fontStyle: 'italic', opacity: '0.5' }}>
         <span style={{ display: 'block' }}>
-          This entity kind "{entity.kind}" is not supported by the EventCatalog
-          plugin.{' '}
-        </span>
-        <span style={{ display: 'block' }}>
-          Please raise an issue on the plugin if you would like to support it.{' '}
-        </span>
-      </div>
-    );
-  }
-
-  // Try and see if there is mapping for the entity name to EventCatalog
-  const eventCatalogResource = backstageToCatalogResourceName(
-    entity,
-    pluginConfig,
-  );
-
-  if (!eventCatalogResource) {
-    return (
-      <div style={{ fontStyle: 'italic', opacity: '0.5' }}>
-        <span style={{ display: 'block' }}>
-          Cannot find a mapping for this entity ({entity.metadata.name}) in
-          EventCatalog.
-        </span>
-        <span style={{ display: 'block' }}>
-          Please provide a <a style={{ textDecoration: "underline", color: "#fff"}} target="_blank" href="https://www.eventcatalog.dev/docs/development/plugins/backstage/api">mapping from the entity name to the EventCatalog ID </a>
-          in the plugin config.
+          Cannot find a mapping for this entity ({resource.entity.metadata.name}) in EventCatalog.
+          Please use annotation eventcatalog.dev/id to map the entity to an EventCatalog resource.
         </span>
       </div>
     );
   }
 
   let url = new URL(
-    `/${page}/${collection}/${eventCatalogResource.id}/${eventCatalogResource.version}?embed=true`,
+    `/${page}/${collection}/${eventCatalogResourceId}?embed=true`,
     pluginConfig.URL,
-  ).toString();
+  );
+
+  if(eventCatalogResourceVersion) {
+    url = new URL(
+      `/${page}/${collection}/${eventCatalogResourceId}/${eventCatalogResourceVersion}?embed=true`,
+      pluginConfig.URL,
+    );
+  };
 
   if(page === 'discover') {
-    const filter = eventCatalogResource.discoverFilter || eventCatalogResource.id;
     url = new URL(
-      `/${page}/${collection}?embed=true&id=${filter}`,
+      `/${page}/${collection}?embed=true`,
       pluginConfig.URL,
-    ).toString();
+    );
   }
 
   return (
     <div style={{ background: 'white', height: '100%' }}>
-      <iframe title={url} src={url} width="100%" height="100%" />
+      <iframe title={url.toString()} src={url.toString()} width="100%" height="100%" />
     </div>
   );
-};
+}
 
 export const EventCatalogEntityVisualiserCard = () => {
   return (<div style={{ height: '100%'}}>
@@ -134,4 +98,3 @@ export const EventCatalogEntityMessageCard = () => {
     <EventCatalogDocumentationEntityPage page="discover" />
   </div>);
 };
-


### PR DESCRIPTION
Implementation for https://github.com/event-catalog/backstage-plugin-eventcatalog/issues/12

Breaking Changes.

- Now uses annotations for mappings to EventCatalog ids and versions
- No longer uses map in config file